### PR TITLE
Allows alternate image names for testing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+### Alternate image name, for testing, etc
+IMAGE="${1:-ocm-container}"
+
 ### cd locally
 cd $(dirname $0)
 
@@ -41,8 +44,7 @@ date -u
 # we want the $@ args here to be re-split
 time ${CONTAINER_SUBSYS}  build \
   --build-arg osv4client=${osv4client} \
-  $@ \
-  -t ocm-container .
+  --tag ${IMAGE} .
 
 # for time tracking
 date

--- a/ocm-container.sh
+++ b/ocm-container.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+### Alternate image name, for testing, etc
+IMAGE="${1:-ocm-container}"
+
 ### cd locally
 cd $(dirname $0)
 
@@ -18,7 +21,7 @@ source ${OCM_CONTAINER_CONFIGFILE}
 
 operating_system=`uname`
 
-SSH_AGENT_MOUNT="-v ${SSH_AUTH_SOCK}:/tmp/ssh.sock:ro"
+SSH_AGENT_MOUNT="--volume ${SSH_AUTH_SOCK}:/tmp/ssh.sock:ro"
 
 if [[ "$operating_system" == "Darwin" ]]
 then
@@ -26,13 +29,17 @@ then
 fi
 
 ### start container
-${CONTAINER_SUBSYS} run -it --rm --privileged \
--e "OCM_URL=${OCM_URL}" \
--e "SSH_AUTH_SOCK=/tmp/ssh.sock" \
--v ${CONFIG_DIR}:/root/.config/ocm-container:ro \
-${SSH_AGENT_MOUNT} \
--v ${HOME}/.ssh:/root/.ssh:ro \
--v ${HOME}/.aws/credentials:/root/.aws/credentials:ro \
--v ${HOME}/.aws/config:/root/.aws/config:ro \
-${OCM_CONTAINER_LAUNCH_OPTS} \
-ocm-container ${SSH_AUTH_ENABLE} /bin/bash 
+${CONTAINER_SUBSYS} run \
+    --interactive \
+    --tty \
+    --rm \
+    --privileged \
+    --env "OCM_URL=${OCM_URL}" \
+    --env "SSH_AUTH_SOCK=/tmp/ssh.sock" \
+    --volume ${CONFIG_DIR}:/root/.config/ocm-container:ro \
+    ${SSH_AGENT_MOUNT} \
+    --volume ${HOME}/.ssh:/root/.ssh:ro \
+    --volume ${HOME}/.aws/credentials:/root/.aws/credentials:ro \
+    --volume ${HOME}/.aws/config:/root/.aws/config:ro \
+    ${OCM_CONTAINER_LAUNCH_OPTS} \
+    ${IMAGE} ${SSH_AUTH_ENABLE} /bin/bash


### PR DESCRIPTION
Adjusts build.sh and ocm-container.sh to allow optional arguments for the container image name to use, to make testing easier.  This allows for development and testing of an ocm-container image without breaking an image you might be using in production (for example, if you're currently shift Primary...theoretically...).

Usage:

```
# Normal
./build
./ocm-container

# Testing; will create and run an image named `ocm-container:testing`
./build ocm-container:testing
./ocm-container ocm-container:testing
```

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>